### PR TITLE
feat(gainmlp): Gain-MLP HDR reconstruction consumer + Python trainer (Canham 2025)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ zensim = "0.2.6"
 # directly (avoids needing a real trained bake on disk for unit-style
 # testing). Path-dep to keep all the sinusoidal-branch code coherent.
 zenpredict-bake = { path = "../zenanalyze--featuretransform-sinusoidal/zenpredict-bake", default-features = false }
+# Cross-crate `'zmlp'` transport test: bake → AVIF muxer → AVIF parser
+# → decoder produces byte-identical output. Path-deps until
+# zenavif-serialize#2 and zenavif-parse#6 land + ship a release.
+zenavif-serialize = { path = "../zenavif-serialize--gainmlp" }
+zenavif-parse = { path = "../zenavif-parse--zmlp-extractor" }
 
 # Native-only: benchmark dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,18 +41,30 @@ avx512 = ["archmage/avx512", "magetypes/avx512"]
 # until stabilized. (The ISO 21496-1 / Apple Ultra HDR gain-map splitter formerly
 # gated here graduated to the always-available `gainmap` module.)
 experimental = []
+# Gain-MLP (Canham et al. 2025) per-pixel HDR reconstruction. Pulls
+# in zenpredict for ZNPR v3 bake loading + MLP forward; otherwise zero
+# zentone API surface depends on zenpredict.
+gainmap-mlp = ["dep:zenpredict"]
 
 [dependencies]
 linear-srgb = { version = "0.6.12", default-features = false, features = ["transfer"] }
 libm = { version = "0.2", default-features = false }
 archmage = { version = "0.9.22", default-features = false, features = ["macros"] }
 magetypes = { version = "0.9.22", default-features = false }
+# Optional — feature-gated; supports no_std default. Path dep for now;
+# flips to a published version once zenanalyze#77
+# (FeatureTransform::Sinusoidal) lands on main and ships a release.
+zenpredict = { path = "../zenanalyze--featuretransform-sinusoidal/zenpredict", default-features = false, optional = true }
 
 [dev-dependencies]
 gainforge = "0.4.1"
 moxcms = "0.8.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
 zensim = "0.2.6"
+# Used by Gain-MLP integration tests to bake synthetic ZNPR v3 models
+# directly (avoids needing a real trained bake on disk for unit-style
+# testing). Path-dep to keep all the sinusoidal-branch code coherent.
+zenpredict-bake = { path = "../zenanalyze--featuretransform-sinusoidal/zenpredict-bake", default-features = false }
 
 # Native-only: benchmark dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/examples/gainmlp_roundtrip.rs
+++ b/examples/gainmlp_roundtrip.rs
@@ -1,0 +1,263 @@
+//! End-to-end Gain-MLP round-trip:
+//!
+//!   1. Generate (or load) an HDR / SDR image pair.
+//!   2. Load a trained Gain-MLP bake (produced by
+//!      `tools/train_gain_mlp.py`).
+//!   3. Reconstruct HDR via `GainMapMlpDecoder` and report PSNR vs
+//!      ground truth.
+//!
+//! USAGE
+//! -----
+//!
+//! ```text
+//! # 1. Train + dump the training pair as .npy:
+//! python3 tools/train_gain_mlp.py --synthetic-pair \
+//!     --out /tmp/gainmlp.bin --dump-pair /tmp/gainmlp --epochs 5000
+//!
+//! # 2. Reload the exact pair the trainer saw + reconstruct:
+//! cargo run --release --example gainmlp_roundtrip --features gainmap-mlp -- \
+//!     /tmp/gainmlp.bin --hdr /tmp/gainmlp_hdr.npy --sdr /tmp/gainmlp_sdr.npy
+//! ```
+//!
+//! Reconstruction PSNR is reported in dB. Canham 2025 hits 48.5 dB on
+//! their real-image corpus; the smoke test here on a 128 × 128
+//! synthetic chromatic-noise pair achieves 52.7 dB at 5000 epochs.
+//!
+//! For real HDR/SDR pairs, point `--hdr` / `--sdr` at NumPy `.npy`
+//! files (float32 (H, W, 3) row-major) produced by your own
+//! pre-processor. The trainer's `--dump-pair` flag exists to make
+//! the synthetic case reproducible; real pipelines convert their
+//! HDR/SDR sources directly into .npy.
+
+#![cfg(feature = "gainmap-mlp")]
+
+use std::env;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use zenpredict::Model;
+use zentone::{GainMapMlpConfig, GainMapMlpDecoder};
+
+fn print_usage_and_exit() -> ExitCode {
+    eprintln!("usage: gainmlp_roundtrip <bake.bin> --hdr <hdr.npy> --sdr <sdr.npy>");
+    ExitCode::from(2)
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.is_empty() {
+        return print_usage_and_exit();
+    }
+    let bake_path = PathBuf::from(&args[0]);
+    let mut hdr_path: Option<PathBuf> = None;
+    let mut sdr_path: Option<PathBuf> = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--hdr" => {
+                hdr_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            "--sdr" => {
+                sdr_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            _ => {
+                eprintln!("unrecognised flag: {}", args[i]);
+                return print_usage_and_exit();
+            }
+        }
+    }
+
+    let bake_bytes = match std::fs::read(&bake_path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("failed to read bake {:?}: {e}", bake_path);
+            return ExitCode::FAILURE;
+        }
+    };
+    let aligned = AlignedBuf::from(bake_bytes);
+    let model = match Model::from_bytes(aligned.as_slice()) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("failed to parse bake: {e:?}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let hdr_p = match hdr_path {
+        Some(p) => p,
+        None => return print_usage_and_exit(),
+    };
+    let sdr_p = match sdr_path {
+        Some(p) => p,
+        None => return print_usage_and_exit(),
+    };
+    let (width, height, hdr, sdr) = match load_pair(&hdr_p, &sdr_p) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("load_pair failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut decoder = match GainMapMlpDecoder::new(
+        &model,
+        width as u32,
+        height as u32,
+        GainMapMlpConfig::default(),
+    ) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("decoder construction failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let mut hdr_reconstructed = vec![0.0_f32; sdr.len()];
+    if let Err(e) = decoder.apply_image(width as u32, height as u32, &sdr, &mut hdr_reconstructed) {
+        eprintln!("apply_image failed: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    let psnr = peak_signal_noise_ratio(&hdr, &hdr_reconstructed);
+    println!("Gain-MLP round-trip:");
+    println!("  bake:        {:?} ({} bytes)", bake_path, aligned.len());
+    println!("  image:       {width} × {height}");
+    println!(
+        "  hdr range:   [{:.4}, {:.4}]",
+        min_finite(&hdr),
+        max_finite(&hdr)
+    );
+    println!(
+        "  recon range: [{:.4}, {:.4}]",
+        min_finite(&hdr_reconstructed),
+        max_finite(&hdr_reconstructed)
+    );
+    println!("  PSNR (dB):   {psnr:.2}");
+    println!("  Canham 2025 paper PSNR target: 48.5 dB");
+
+    ExitCode::SUCCESS
+}
+
+fn load_pair(
+    hdr_path: &PathBuf,
+    sdr_path: &PathBuf,
+) -> Result<(usize, usize, Vec<f32>, Vec<f32>), String> {
+    // Light .npy reader covering the minimum f32 RGB case. Full npy
+    // parsing lives in the Python tool; this just handles the trainer's
+    // output shape for round-trip validation.
+    let hdr_bytes = std::fs::read(hdr_path).map_err(|e| format!("read hdr: {e}"))?;
+    let (h, w, hdr) = parse_npy_f32_rgb(&hdr_bytes)?;
+
+    let sdr_bytes = std::fs::read(sdr_path).map_err(|e| format!("read sdr: {e}"))?;
+    let (sh, sw, sdr) = parse_npy_f32_rgb(&sdr_bytes)?;
+    if (sh, sw) != (h, w) {
+        return Err(format!("hdr/sdr shape mismatch: ({h},{w}) vs ({sh},{sw})"));
+    }
+    Ok((w, h, hdr, sdr))
+}
+
+fn parse_npy_f32_rgb(bytes: &[u8]) -> Result<(usize, usize, Vec<f32>), String> {
+    // NPY v1.0 header. We accept only the minimal shape this script
+    // needs — float32, C-order, shape (H, W, 3).
+    if bytes.len() < 10 || &bytes[..6] != b"\x93NUMPY" {
+        return Err("not a NumPy .npy file".into());
+    }
+    let major = bytes[6];
+    if major != 1 {
+        return Err(format!("only NPY v1 supported, got v{major}"));
+    }
+    let header_len = u16::from_le_bytes([bytes[8], bytes[9]]) as usize;
+    let header = core::str::from_utf8(&bytes[10..10 + header_len])
+        .map_err(|e| format!("header utf8: {e}"))?;
+    if !header.contains("'descr': '<f4'") && !header.contains("'descr': '|f4'") {
+        return Err(format!("expected float32 descr, header: {header:?}"));
+    }
+    let shape_start = header.find('(').ok_or("no shape")? + 1;
+    let shape_end = header[shape_start..].find(')').ok_or("no shape end")? + shape_start;
+    let shape_str = &header[shape_start..shape_end];
+    let dims: Vec<usize> = shape_str
+        .split(',')
+        .filter_map(|s| {
+            let s = s.trim();
+            if s.is_empty() {
+                None
+            } else {
+                s.parse::<usize>().ok()
+            }
+        })
+        .collect();
+    if dims.len() != 3 || dims[2] != 3 {
+        return Err(format!("expected (H, W, 3), got {dims:?}"));
+    }
+    let (h, w) = (dims[0], dims[1]);
+    let data_start = 10 + header_len;
+    let n = h * w * 3;
+    let want = n * 4;
+    if data_start + want > bytes.len() {
+        return Err("truncated array".into());
+    }
+    let mut data = vec![0.0_f32; n];
+    for (i, slot) in data.iter_mut().enumerate() {
+        let off = data_start + i * 4;
+        *slot = f32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]]);
+    }
+    Ok((h, w, data))
+}
+
+fn peak_signal_noise_ratio(reference: &[f32], reconstructed: &[f32]) -> f32 {
+    let n = reference.len().min(reconstructed.len()) as f32;
+    if n == 0.0 {
+        return 0.0;
+    }
+    let mut mse = 0.0_f64;
+    let mut peak = 0.0_f32;
+    for (r, rec) in reference.iter().zip(reconstructed.iter()) {
+        let d = r - rec;
+        mse += (d * d) as f64;
+        if r.abs() > peak {
+            peak = r.abs();
+        }
+    }
+    mse /= n as f64;
+    if mse == 0.0 {
+        return f32::INFINITY;
+    }
+    let peak = peak.max(1.0); // avoid degenerate
+    (10.0 * ((peak as f64).powi(2) / mse).log10()) as f32
+}
+
+fn min_finite(xs: &[f32]) -> f32 {
+    let mut m = f32::INFINITY;
+    for &x in xs {
+        if x.is_finite() && x < m {
+            m = x;
+        }
+    }
+    m
+}
+
+fn max_finite(xs: &[f32]) -> f32 {
+    let mut m = f32::NEG_INFINITY;
+    for &x in xs {
+        if x.is_finite() && x > m {
+            m = x;
+        }
+    }
+    m
+}
+
+#[repr(C, align(16))]
+struct AlignedBuf(Vec<u8>);
+impl AlignedBuf {
+    fn from(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+    fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,8 @@
 //! Error type.
 
+#[cfg(feature = "gainmap-mlp")]
+extern crate alloc;
+
 use core::fmt;
 
 /// Result alias for zentone.
@@ -9,6 +12,18 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Error {
+    /// Gain-MLP decoder rejected the supplied bake or call. The
+    /// `&'static str` is a short identifier (e.g.
+    /// `"Gain-MLP bake must have n_outputs = 3"`) — the full
+    /// rationale lives in `gainmap_mlp.rs`'s docstrings.
+    GainMapMlp(&'static str),
+    /// Underlying zenpredict failure during Gain-MLP forward pass.
+    /// Carries the `Debug` representation of the original
+    /// [`zenpredict::PredictError`] so the wrapper stays
+    /// `Clone + PartialEq + Eq` without depending on the upstream
+    /// type's derives.
+    #[cfg(feature = "gainmap-mlp")]
+    GainMapMlpPredict(alloc::string::String),
     /// Input buffer is too small for the declared dimensions and channel count.
     BufferTooSmall {
         /// Required length in elements.
@@ -75,7 +90,28 @@ impl fmt::Display for Error {
                 write!(f, "streaming ring buffer full — pull a row before pushing")
             }
             Error::InvalidConfig(msg) => write!(f, "invalid config: {msg}"),
+            Error::GainMapMlp(msg) => write!(f, "gain-mlp: {msg}"),
+            #[cfg(feature = "gainmap-mlp")]
+            Error::GainMapMlpPredict(msg) => write!(f, "gain-mlp predict: {msg}"),
         }
+    }
+}
+
+impl Error {
+    /// Gain-MLP runtime error with a short static identifier.
+    pub(crate) const fn gainmap_mlp(msg: &'static str) -> Self {
+        Self::GainMapMlp(msg)
+    }
+
+    /// Wrap a `zenpredict::PredictError` for the Gain-MLP path.
+    /// Goes through `Debug` so the error type stays
+    /// `Clone + PartialEq + Eq` without depending on upstream derives.
+    #[cfg(feature = "gainmap-mlp")]
+    pub(crate) fn gainmap_mlp_predict(e: zenpredict::PredictError) -> Self {
+        use core::fmt::Write;
+        let mut buf = alloc::string::String::with_capacity(64);
+        let _ = write!(&mut buf, "{e:?}");
+        Self::GainMapMlpPredict(buf)
     }
 }
 

--- a/src/gainmap_mlp.rs
+++ b/src/gainmap_mlp.rs
@@ -1,0 +1,331 @@
+//! Gain-MLP per-pixel HDR reconstruction (Canham et al. 2025).
+//!
+//! Implements the consumer side of the "Gamma-MLP" / "Gain-MLP" gain
+//! map encoding described in Canham, Pieper, Sankaranarayanan, Roghair,
+//! Mueller (2025), "Encoding High-Dynamic-Range Gain Maps with Small
+//! MLPs". The encoder produces a ~10 KB MLP whose output is the
+//! per-pixel log₂ gain residual that converts an SDR base image to its
+//! HDR original. The MLP takes
+//!
+//!   `[x, y, R, G, B]`
+//!
+//! as input (spatial coordinates in `[0, 1]`, SDR colour in `[0, 1]`)
+//! and emits a 3-channel `log₂(gain)` per pixel. The HDR
+//! reconstruction is
+//!
+//! ```text
+//! H_c = (S_c + ε) · 2^MLP(x, y, R, G, B)_c − ε     (c ∈ {R, G, B})
+//! ```
+//!
+//! ε is the ISO 21496-1 alternate offset (typical: `1/64 ≈ 0.0156`).
+//! See [`GainMapMlpConfig`] for the encoded knob.
+//!
+//! ## Wire format / bake layout
+//!
+//! The bake is a standard ZNPR v3 (zenpredict) MLP carrying:
+//!
+//! - **`scaler_mean` / `scaler_scale`** sized to the expanded input
+//!   width (post-sinusoidal embedding), typically 120 floats.
+//! - **First-layer `in_dim = 120`** (matching the embedding output).
+//! - **Final-layer `out_dim = 3`** (per-channel log₂ gain).
+//! - **`zentrain.feature_transforms`** metadata:
+//!   `"sinusoidal\nsinusoidal\nsinusoidal\nsinusoidal\nsinusoidal"`
+//!   (one per raw input feature x, y, R, G, B).
+//! - **`zentrain.feature_transform_params`** metadata: comma-separated
+//!   frequencies per feature, e.g. `"1,2,4,8,16,32,64,128,256,512,1024,2048"`
+//!   on each line. Each line declares 12 frequencies ⇒ 2·12 = 24
+//!   outputs per input ⇒ 5 · 24 = 120 embedded inputs.
+//!
+//! The Predictor handles the embedding + scaler + forward; this
+//! module's job is supplying the `[x, y, R, G, B]` input vector
+//! per pixel and applying the reconstruction formula to the MLP
+//! output.
+//!
+//! ## Coordinate convention
+//!
+//! `x` and `y` are **normalised to `[0, 1]`** (top-left = `(0, 0)`,
+//! bottom-right = `(1, 1)`). The trainer must use the same
+//! convention; the frequency schedule encoded in
+//! `feature_transform_params` is calibrated against this unit-square
+//! coordinate space. Pixel-coordinate models would need an entirely
+//! different frequency schedule and are not supported by this
+//! consumer.
+//!
+//! ## Bit-depth + colour-space contract
+//!
+//! Inputs are interleaved `f32` rows with channels = 3 (RGB) in
+//! linear or sRGB-encoded `[0, 1]` SDR. The MLP is trained against
+//! whatever colour space the encoder produced, so the consumer is
+//! colour-space-agnostic — but consumer + encoder MUST agree. Outputs
+//! are interleaved `f32` HDR in linear light, no normalisation
+//! enforced beyond `H_c ≥ 0` after the ε subtract clamps.
+
+#![cfg(feature = "gainmap-mlp")]
+
+use zenpredict::{Model, Predictor};
+
+use crate::error::{Error, Result};
+
+/// Default alternate offset (`1/64 ≈ 0.015625`), matching the
+/// ISO 21496-1 reference implementation and Adobe / Apple Ultra HDR.
+pub const DEFAULT_EPSILON: f32 = 1.0 / 64.0;
+
+/// Encoder-side configuration knob carried alongside the bake.
+///
+/// Today only `epsilon` is decoder-visible; future fields (per-channel
+/// ε, log-window override, content-light hints) land here as the spec
+/// stabilises.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct GainMapMlpConfig {
+    /// Alternate offset in the ISO 21496-1 formula `H = (S + ε) · 2^g − ε`.
+    /// Default: [`DEFAULT_EPSILON`].
+    pub epsilon: f32,
+}
+
+impl Default for GainMapMlpConfig {
+    fn default() -> Self {
+        Self {
+            epsilon: DEFAULT_EPSILON,
+        }
+    }
+}
+
+/// Per-pixel HDR reconstruction driver. Holds a [`Predictor`] borrowing
+/// the supplied [`Model`] and applies the
+/// `H = (S + ε) · 2^MLP − ε` formula to each pixel of an interleaved
+/// RGB row.
+///
+/// One instance per thread; the underlying `Predictor` reuses
+/// per-call scratch buffers across pixels.
+pub struct GainMapMlpDecoder<'a> {
+    predictor: Predictor<'a>,
+    cfg: GainMapMlpConfig,
+    inv_width: f32,
+    inv_height: f32,
+    /// Scratch buffer for the 5-D raw input vector `[x, y, R, G, B]`.
+    /// One per-pixel allocation amortised across rows.
+    raw_input: [f32; 5],
+}
+
+impl<'a> GainMapMlpDecoder<'a> {
+    /// Construct a decoder for an image of `width × height` pixels.
+    ///
+    /// The image dimensions are baked into the coord normaliser so
+    /// per-row apply only needs the row's `y` index and pixel x indices
+    /// — they're normalised internally.
+    ///
+    /// `width` and `height` must be ≥ 1; the constructor panics
+    /// otherwise (decoder construction is a build-time invariant
+    /// rather than a per-call check).
+    pub fn new(
+        model: &'a Model,
+        width: u32,
+        height: u32,
+        cfg: GainMapMlpConfig,
+    ) -> Result<Self> {
+        if width == 0 || height == 0 {
+            return Err(Error::gainmap_mlp(
+                "width and height must be >= 1",
+            ));
+        }
+        validate_bake_shape(model)?;
+        Ok(Self {
+            predictor: Predictor::new(model),
+            cfg,
+            inv_width: 1.0 / (width.max(1) as f32),
+            inv_height: 1.0 / (height.max(1) as f32),
+            raw_input: [0.0; 5],
+        })
+    }
+
+    /// Reconstruct one HDR row from one SDR row. Both rows are
+    /// `f32` interleaved RGB, `width` pixels long ⇒ `3 * width` floats.
+    ///
+    /// `y_pixel` is the row's pixel index in `0..height`. The decoder
+    /// normalises to `y_pixel / (height - 1)` so the top row sees
+    /// `y_norm = 0.0` and the bottom row sees `y_norm = 1.0`. For a
+    /// 1-row image the normaliser degenerates to `0.0` — fine because
+    /// the MLP only sees one y value during training.
+    pub fn apply_row(
+        &mut self,
+        y_pixel: u32,
+        sdr_row: &[f32],
+        hdr_row: &mut [f32],
+    ) -> Result<()> {
+        if sdr_row.len() != hdr_row.len() {
+            return Err(Error::gainmap_mlp(
+                "sdr_row and hdr_row must be the same length",
+            ));
+        }
+        if !sdr_row.len().is_multiple_of(3) {
+            return Err(Error::gainmap_mlp(
+                "row length must be a multiple of 3 (interleaved RGB)",
+            ));
+        }
+        let width = sdr_row.len() / 3;
+        let y_norm = if self.inv_height < 1.0 {
+            (y_pixel as f32) * self.inv_height
+        } else {
+            0.0
+        };
+        let eps = self.cfg.epsilon;
+        for px in 0..width {
+            let x_norm = (px as f32) * self.inv_width;
+            let r = sdr_row[px * 3];
+            let g = sdr_row[px * 3 + 1];
+            let b = sdr_row[px * 3 + 2];
+            self.raw_input = [x_norm, y_norm, r, g, b];
+            let mlp_out = self
+                .predictor
+                .predict_transformed(&self.raw_input)
+                .map_err(Error::gainmap_mlp_predict)?;
+            if mlp_out.len() != 3 {
+                return Err(Error::gainmap_mlp(
+                    "bake must produce 3 outputs (per-channel log2 gain)",
+                ));
+            }
+            // H_c = (S_c + ε) · 2^MLP_c − ε
+            hdr_row[px * 3] = (r + eps) * exp2(mlp_out[0]) - eps;
+            hdr_row[px * 3 + 1] = (g + eps) * exp2(mlp_out[1]) - eps;
+            hdr_row[px * 3 + 2] = (b + eps) * exp2(mlp_out[2]) - eps;
+        }
+        Ok(())
+    }
+
+    /// Reconstruct the entire HDR image from an SDR image. Convenience
+    /// wrapper over [`Self::apply_row`].
+    ///
+    /// `width × height` must equal `sdr.len() / 3 == hdr.len() / 3`.
+    pub fn apply_image(
+        &mut self,
+        width: u32,
+        height: u32,
+        sdr: &[f32],
+        hdr: &mut [f32],
+    ) -> Result<()> {
+        if sdr.len() != hdr.len() {
+            return Err(Error::gainmap_mlp("sdr and hdr must be the same length"));
+        }
+        let expected = (width as usize) * (height as usize) * 3;
+        if sdr.len() != expected {
+            return Err(Error::gainmap_mlp(
+                "buffer length must equal width * height * 3",
+            ));
+        }
+        let row_pixels = width as usize;
+        let row_floats = row_pixels * 3;
+        for y in 0..height {
+            let row_start = (y as usize) * row_floats;
+            let row_end = row_start + row_floats;
+            self.apply_row(y, &sdr[row_start..row_end], &mut hdr[row_start..row_end])?;
+        }
+        Ok(())
+    }
+
+    /// Reconstruct one pixel — the lowest-level entry point. Mostly
+    /// useful for testing and for callers integrating the decoder into
+    /// a different row-iteration loop (e.g., tile-based).
+    pub fn apply_pixel(&mut self, x_norm: f32, y_norm: f32, sdr: [f32; 3]) -> Result<[f32; 3]> {
+        self.raw_input = [x_norm, y_norm, sdr[0], sdr[1], sdr[2]];
+        let mlp_out = self
+            .predictor
+            .predict_transformed(&self.raw_input)
+            .map_err(Error::gainmap_mlp_predict)?;
+        if mlp_out.len() != 3 {
+            return Err(Error::gainmap_mlp(
+                "bake must produce 3 outputs (per-channel log2 gain)",
+            ));
+        }
+        let eps = self.cfg.epsilon;
+        Ok([
+            (sdr[0] + eps) * exp2(mlp_out[0]) - eps,
+            (sdr[1] + eps) * exp2(mlp_out[1]) - eps,
+            (sdr[2] + eps) * exp2(mlp_out[2]) - eps,
+        ])
+    }
+
+    /// Return the decoder's configured ε.
+    pub fn epsilon(&self) -> f32 {
+        self.cfg.epsilon
+    }
+}
+
+/// Validate that the loaded bake has the shape this consumer expects.
+///
+/// Specifically:
+/// - `n_outputs == 3` (per-channel log₂ gain).
+/// - `feature_transforms.len() == 5` (raw inputs x, y, R, G, B).
+/// - All five transforms are `Sinusoidal` (the embedding lives in
+///   the bake; the consumer only handles unit-coordinate normalisation
+///   and the reconstruction formula).
+///
+/// Returns a descriptive error so a misconfigured bake fails loudly
+/// at construction rather than producing wrong pixels per call.
+fn validate_bake_shape(model: &Model) -> Result<()> {
+    if model.n_outputs() != 3 {
+        return Err(Error::gainmap_mlp(
+            "bake must have n_outputs = 3 (per-channel log2 gain)",
+        ));
+    }
+    let transforms = model.feature_transforms().ok_or_else(|| {
+        Error::gainmap_mlp(
+            "bake must declare zentrain.feature_transforms with sinusoidal embeddings",
+        )
+    })?;
+    if transforms.len() != 5 {
+        return Err(Error::gainmap_mlp(
+            "bake must declare exactly 5 raw input features (x, y, R, G, B)",
+        ));
+    }
+    for t in transforms {
+        if !t.is_expander() {
+            return Err(Error::gainmap_mlp(
+                "each raw input feature must use FeatureTransform::Sinusoidal",
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// `2^x` portable across std / no_std builds.
+#[inline]
+fn exp2(x: f32) -> f32 {
+    #[cfg(feature = "std")]
+    {
+        x.exp2()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        libm::exp2f(x)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The bake-load + Predictor end-to-end tests live in
+    // `tests/gainmap_mlp_integration.rs` (where `zenpredict-bake` is
+    // available as a dev-dep). Unit tests here focus on the math
+    // helpers + config defaults.
+
+    #[test]
+    fn default_epsilon_matches_iso_21496_1() {
+        let cfg = GainMapMlpConfig::default();
+        assert_eq!(cfg.epsilon, 1.0 / 64.0);
+        assert_eq!(cfg.epsilon, DEFAULT_EPSILON);
+    }
+
+    #[test]
+    fn exp2_matches_std() {
+        for x in [0.0_f32, 1.0, -1.0, 0.5, 2.5, -3.25] {
+            let theirs = exp2(x);
+            let ours = x.exp2();
+            assert!(
+                (theirs - ours).abs() < 1e-6,
+                "exp2({x}) drift: {theirs} vs {ours}"
+            );
+        }
+    }
+}

--- a/src/gainmap_mlp.rs
+++ b/src/gainmap_mlp.rs
@@ -118,23 +118,32 @@ impl<'a> GainMapMlpDecoder<'a> {
     /// `width` and `height` must be ≥ 1; the constructor panics
     /// otherwise (decoder construction is a build-time invariant
     /// rather than a per-call check).
-    pub fn new(
-        model: &'a Model,
-        width: u32,
-        height: u32,
-        cfg: GainMapMlpConfig,
-    ) -> Result<Self> {
+    pub fn new(model: &'a Model, width: u32, height: u32, cfg: GainMapMlpConfig) -> Result<Self> {
         if width == 0 || height == 0 {
-            return Err(Error::gainmap_mlp(
-                "width and height must be >= 1",
-            ));
+            return Err(Error::gainmap_mlp("width and height must be >= 1"));
         }
         validate_bake_shape(model)?;
+        // Normalise coordinates to **[0, 1] inclusive** to match the
+        // trainer convention `idx / (n - 1)`. A 1-pixel axis collapses
+        // to the constant 0 (no division). This must match the trainer
+        // exactly — the sinusoidal frequency schedule is calibrated
+        // against this coordinate space and high-frequency terms are
+        // wildly sensitive to a single-pixel offset.
+        let inv_width = if width > 1 {
+            1.0 / ((width - 1) as f32)
+        } else {
+            0.0
+        };
+        let inv_height = if height > 1 {
+            1.0 / ((height - 1) as f32)
+        } else {
+            0.0
+        };
         Ok(Self {
             predictor: Predictor::new(model),
             cfg,
-            inv_width: 1.0 / (width.max(1) as f32),
-            inv_height: 1.0 / (height.max(1) as f32),
+            inv_width,
+            inv_height,
             raw_input: [0.0; 5],
         })
     }
@@ -147,12 +156,7 @@ impl<'a> GainMapMlpDecoder<'a> {
     /// `y_norm = 0.0` and the bottom row sees `y_norm = 1.0`. For a
     /// 1-row image the normaliser degenerates to `0.0` — fine because
     /// the MLP only sees one y value during training.
-    pub fn apply_row(
-        &mut self,
-        y_pixel: u32,
-        sdr_row: &[f32],
-        hdr_row: &mut [f32],
-    ) -> Result<()> {
+    pub fn apply_row(&mut self, y_pixel: u32, sdr_row: &[f32], hdr_row: &mut [f32]) -> Result<()> {
         if sdr_row.len() != hdr_row.len() {
             return Err(Error::gainmap_mlp(
                 "sdr_row and hdr_row must be the same length",
@@ -164,11 +168,7 @@ impl<'a> GainMapMlpDecoder<'a> {
             ));
         }
         let width = sdr_row.len() / 3;
-        let y_norm = if self.inv_height < 1.0 {
-            (y_pixel as f32) * self.inv_height
-        } else {
-            0.0
-        };
+        let y_norm = (y_pixel as f32) * self.inv_height;
         let eps = self.cfg.epsilon;
         for px in 0..width {
             let x_norm = (px as f32) * self.inv_width;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,8 @@ pub mod curves;
 mod error;
 mod filmic_spline;
 pub mod gainmap;
+#[cfg(feature = "gainmap-mlp")]
+pub mod gainmap_mlp;
 pub mod gamut;
 pub mod hlg;
 mod math;
@@ -227,6 +229,8 @@ pub use gainmap::{
     Bt2408Yrgb, ExtendedReinhardLuma, HableFilmic, LumaFn, LumaGainMapSplitter, LumaToneMap,
     SplitConfig, SplitStats,
 };
+#[cfg(feature = "gainmap-mlp")]
+pub use gainmap_mlp::{DEFAULT_EPSILON, GainMapMlpConfig, GainMapMlpDecoder};
 pub use scratch::TonemapScratch;
 pub use tone_map::ToneMap;
 

--- a/tests/avif_roundtrip.rs
+++ b/tests/avif_roundtrip.rs
@@ -1,0 +1,188 @@
+//! End-to-end Gain-MLP transport test: bake bytes → AVIF muxer
+//! ([`zenavif_serialize::Aviffy::set_gain_map_mlp_bake`]) → AVIF parser
+//! ([`zenavif_parse::AvifParser::gain_map_mlp_bake`]) → [`GainMapMlpDecoder`].
+//!
+//! Validates that round-tripping the bake through an ISOBMFF container
+//! produces byte-identical bytes AND byte-identical decoder outputs vs
+//! running the same bake directly. This is the cross-crate contract
+//! test for the experimental `'zmlp'` auxiliary item type.
+
+#![cfg(feature = "gainmap-mlp")]
+
+use zenpredict::{Activation, MetadataType, Model, WeightDtype, keys};
+use zenpredict_bake::{BakeLayer, BakeMetadataEntry, BakeRequest, bake};
+use zentone::{GainMapMlpConfig, GainMapMlpDecoder};
+
+#[repr(C, align(16))]
+struct Aligned(Vec<u8>);
+
+/// Reproduces the constant-gain bake shape used by
+/// [`gainmap_mlp_integration`] so this test is self-contained.
+fn make_constant_gain_bake(num_freqs: usize, constant_log2_gain: [f32; 3]) -> Vec<u8> {
+    let arity = 2 * num_freqs;
+    let expanded_dim = 5 * arity;
+    let hidden_dim = 4;
+    let scaler_mean = vec![0.0_f32; expanded_dim];
+    let scaler_scale = vec![1.0_f32; expanded_dim];
+    let l0_weights = vec![0.0_f32; expanded_dim * hidden_dim];
+    let l0_biases = vec![0.0_f32; hidden_dim];
+    let l1_weights = vec![0.0_f32; hidden_dim * 3];
+    let l1_biases = constant_log2_gain.to_vec();
+    let layers = [
+        BakeLayer {
+            in_dim: expanded_dim,
+            out_dim: hidden_dim,
+            activation: Activation::Relu,
+            dtype: WeightDtype::F32,
+            weights: &l0_weights,
+            biases: &l0_biases,
+        },
+        BakeLayer {
+            in_dim: hidden_dim,
+            out_dim: 3,
+            activation: Activation::Identity,
+            dtype: WeightDtype::F32,
+            weights: &l1_weights,
+            biases: &l1_biases,
+        },
+    ];
+    let transforms_txt = b"sinusoidal\nsinusoidal\nsinusoidal\nsinusoidal\nsinusoidal";
+    let freq_line: String = (0..num_freqs)
+        .map(|k| (1u32 << k).to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut params_txt = Vec::new();
+    for i in 0..5 {
+        if i > 0 {
+            params_txt.push(b'\n');
+        }
+        params_txt.extend_from_slice(freq_line.as_bytes());
+    }
+    let metadata = [
+        BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORMS,
+            kind: MetadataType::Utf8,
+            value: transforms_txt,
+        },
+        BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORM_PARAMS,
+            kind: MetadataType::Utf8,
+            value: &params_txt,
+        },
+    ];
+    bake(&BakeRequest {
+        schema_hash: 0xfeed_face_dead_beef,
+        flags: 0,
+        scaler_mean: &scaler_mean,
+        scaler_scale: &scaler_scale,
+        layers: &layers,
+        feature_bounds: &[],
+        metadata: &metadata,
+        output_specs: &[],
+        discrete_sets: &[],
+        sparse_overrides: &[],
+        feature_order: None,
+        output_order: None,
+        compressed: false,
+        hu_permutations: None,
+    })
+    .expect("bake construction")
+}
+
+/// Minimal tone-map metadata — matches the layout used by both
+/// `zenavif-serialize`'s and `zenavif-parse`'s integration tests so
+/// the muxed file parses cleanly.
+fn make_tmap_metadata() -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.push(0u8);
+    buf.extend_from_slice(&0u16.to_be_bytes());
+    buf.extend_from_slice(&0u16.to_be_bytes());
+    buf.push(1u8 << 6); // use_base_colour_space
+    buf.extend_from_slice(&0u32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&0i32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&1i32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&0i32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&0i32.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf
+}
+
+#[test]
+fn bake_roundtrips_through_avif_container_and_decodes_identically() {
+    let bake_bytes = make_constant_gain_bake(2, [1.0, 0.5, -0.25]);
+
+    let primary_data = b"primary_av1_xyz";
+    let gain_map_data = b"av01_gain_map_xyz";
+    let metadata = make_tmap_metadata();
+    let avif_bytes = zenavif_serialize::Aviffy::new()
+        .set_gain_map(gain_map_data.to_vec(), 4, 4, 8, metadata)
+        .set_gain_map_mlp_bake(bake_bytes.clone())
+        .to_vec(primary_data, None, 10, 20, 8);
+
+    let parser = zenavif_parse::AvifParser::from_bytes(&avif_bytes).expect("parse AVIF");
+    let recovered_bake = parser
+        .gain_map_mlp_bake()
+        .expect("zmlp accessor present")
+        .expect("resolve zmlp extent")
+        .into_owned();
+    assert_eq!(
+        recovered_bake, bake_bytes,
+        "bake bytes must roundtrip byte-identical through AVIF container"
+    );
+
+    // Forward both bakes through GainMapMlpDecoder and compare.
+    let direct = Aligned(bake_bytes);
+    let recovered = Aligned(recovered_bake);
+    let direct_model = Model::from_bytes(&direct.0).expect("direct model");
+    let recovered_model = Model::from_bytes(&recovered.0).expect("recovered model");
+
+    let width = 4u32;
+    let height = 4u32;
+    let mut direct_decoder =
+        GainMapMlpDecoder::new(&direct_model, width, height, GainMapMlpConfig::default())
+            .expect("direct decoder");
+    let mut recovered_decoder =
+        GainMapMlpDecoder::new(&recovered_model, width, height, GainMapMlpConfig::default())
+            .expect("recovered decoder");
+
+    let sdr: Vec<f32> = (0..(width * height * 3) as usize)
+        .map(|i| (i as f32) / ((width * height * 3) as f32))
+        .collect();
+    let mut hdr_direct = vec![0.0_f32; sdr.len()];
+    let mut hdr_recovered = vec![0.0_f32; sdr.len()];
+    direct_decoder
+        .apply_image(width, height, &sdr, &mut hdr_direct)
+        .expect("direct apply_image");
+    recovered_decoder
+        .apply_image(width, height, &sdr, &mut hdr_recovered)
+        .expect("recovered apply_image");
+
+    assert_eq!(
+        hdr_direct, hdr_recovered,
+        "decoder output must be bit-exact between direct and AVIF-recovered bakes"
+    );
+}
+
+#[test]
+fn avif_without_mlp_bake_returns_none() {
+    // Same minting flow but without `set_gain_map_mlp_bake`. The
+    // parser must report `gain_map_mlp_bake() == None` so consumers
+    // can cleanly fall back to the traditional av01 gain map.
+    let primary_data = b"primary";
+    let gain_map_data = b"av01_only";
+    let metadata = make_tmap_metadata();
+    let avif_bytes = zenavif_serialize::Aviffy::new()
+        .set_gain_map(gain_map_data.to_vec(), 4, 4, 8, metadata)
+        .to_vec(primary_data, None, 10, 20, 8);
+    let parser = zenavif_parse::AvifParser::from_bytes(&avif_bytes).expect("parse AVIF");
+    assert!(parser.gain_map_data().is_some());
+    assert!(parser.gain_map_mlp_bake().is_none());
+}

--- a/tests/gainmap_mlp_integration.rs
+++ b/tests/gainmap_mlp_integration.rs
@@ -1,0 +1,348 @@
+//! End-to-end integration tests for [`zentone::gainmap_mlp`].
+//!
+//! Builds Gain-MLP-shaped ZNPR v3 bakes (5-D sinusoidal-embedded input
+//! → identity-passthrough → 3-D output) and runs them through
+//! [`GainMapMlpDecoder`]. The bakes' weights and biases are
+//! hand-constructed so the expected per-pixel HDR output is calculable
+//! by hand, letting us assert byte-exact reconstruction math.
+
+#![cfg(feature = "gainmap-mlp")]
+
+use zenpredict::{Activation, MetadataType, Model, WeightDtype, keys};
+use zenpredict_bake::{BakeLayer, BakeMetadataEntry, BakeRequest, bake};
+use zentone::{GainMapMlpConfig, GainMapMlpDecoder};
+
+#[repr(C, align(16))]
+struct Aligned(Vec<u8>);
+
+/// Build a Gain-MLP-shaped bake with:
+/// - 5 raw inputs (x, y, R, G, B), all `Sinusoidal` with the supplied
+///   frequencies per input (per-input arity = `2 * num_freqs`).
+/// - Total expanded dim = 5 * 2 * num_freqs.
+/// - Two layers: expanded → `hidden_dim` (ReLU), `hidden_dim` → 3 (Identity).
+/// - Weights / biases produce a deterministic 3-output mapping
+///   parameterised by the supplied scalars.
+///
+/// Specifically: `out[c] = constant_bias[c]` regardless of input —
+/// the input layer has all-zero weights so the embedded vector is
+/// ignored, and the hidden bias drives the output. Use this to test
+/// that the decoder's reconstruction math is correct independent of
+/// any learned MLP behaviour.
+fn make_constant_gain_bake(num_freqs: usize, constant_log2_gain: [f32; 3]) -> Vec<u8> {
+    let arity = 2 * num_freqs;
+    let expanded_dim = 5 * arity;
+    let hidden_dim = 4;
+    let scaler_mean = vec![0.0_f32; expanded_dim];
+    let scaler_scale = vec![1.0_f32; expanded_dim];
+
+    // Layer 0: expanded_dim → hidden_dim, all zeros (ignores input).
+    let l0_weights = vec![0.0_f32; expanded_dim * hidden_dim];
+    let l0_biases = vec![0.0_f32; hidden_dim];
+
+    // Layer 1: hidden_dim → 3, zero weights + per-output bias = constant log2 gain.
+    let l1_weights = vec![0.0_f32; hidden_dim * 3];
+    let l1_biases = constant_log2_gain.to_vec();
+
+    let layers = [
+        BakeLayer {
+            in_dim: expanded_dim,
+            out_dim: hidden_dim,
+            activation: Activation::Relu,
+            dtype: WeightDtype::F32,
+            weights: &l0_weights,
+            biases: &l0_biases,
+        },
+        BakeLayer {
+            in_dim: hidden_dim,
+            out_dim: 3,
+            activation: Activation::Identity,
+            dtype: WeightDtype::F32,
+            weights: &l1_weights,
+            biases: &l1_biases,
+        },
+    ];
+
+    // 5 lines of "sinusoidal" tokens (one per raw input).
+    let transforms_txt = b"sinusoidal\nsinusoidal\nsinusoidal\nsinusoidal\nsinusoidal";
+    // 5 lines of identical frequency lists.
+    let mut params_txt = Vec::new();
+    let freq_line: String = (0..num_freqs)
+        .map(|k| (1u32 << k).to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    for i in 0..5 {
+        if i > 0 {
+            params_txt.push(b'\n');
+        }
+        params_txt.extend_from_slice(freq_line.as_bytes());
+    }
+
+    let metadata = [
+        BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORMS,
+            kind: MetadataType::Utf8,
+            value: transforms_txt,
+        },
+        BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORM_PARAMS,
+            kind: MetadataType::Utf8,
+            value: &params_txt,
+        },
+    ];
+
+    bake(&BakeRequest {
+        schema_hash: 0xfeed_face_dead_beef,
+        flags: 0,
+        scaler_mean: &scaler_mean,
+        scaler_scale: &scaler_scale,
+        layers: &layers,
+        feature_bounds: &[],
+        metadata: &metadata,
+        output_specs: &[],
+        discrete_sets: &[],
+        sparse_overrides: &[],
+        feature_order: None,
+        output_order: None,
+        compressed: false,
+        hu_permutations: None,
+    })
+    .expect("bake construction")
+}
+
+#[test]
+fn decoder_rejects_bake_without_sinusoidal_inputs() {
+    // 5 inputs but all `Identity` (not expanders) — must fail at
+    // construction. Don't bother with a real bake; we exercise the
+    // validate_bake_shape path through a mock.
+
+    // Use a non-expander bake by passing `identity` tokens directly.
+    let scaler_mean = vec![0.0_f32; 5];
+    let scaler_scale = vec![1.0_f32; 5];
+    let l0_w = vec![0.0_f32; 5 * 3];
+    let l0_b = vec![0.0_f32; 3];
+    let layers = [BakeLayer {
+        in_dim: 5,
+        out_dim: 3,
+        activation: Activation::Identity,
+        dtype: WeightDtype::F32,
+        weights: &l0_w,
+        biases: &l0_b,
+    }];
+    let metadata = [BakeMetadataEntry {
+        key: keys::FEATURE_TRANSFORMS,
+        kind: MetadataType::Utf8,
+        value: b"identity\nidentity\nidentity\nidentity\nidentity",
+    }];
+    let bytes = bake(&BakeRequest {
+        schema_hash: 1,
+        flags: 0,
+        scaler_mean: &scaler_mean,
+        scaler_scale: &scaler_scale,
+        layers: &layers,
+        feature_bounds: &[],
+        metadata: &metadata,
+        output_specs: &[],
+        discrete_sets: &[],
+        sparse_overrides: &[],
+        feature_order: None,
+        output_order: None,
+        compressed: false,
+        hu_permutations: None,
+    })
+    .expect("bake");
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    let err = match GainMapMlpDecoder::new(&model, 64, 64, GainMapMlpConfig::default()) {
+        Ok(_) => panic!("expected validate_bake_shape to reject this bake"),
+        Err(e) => e,
+    };
+    let s = format!("{err}");
+    assert!(
+        s.contains("Sinusoidal"),
+        "expected validate_bake_shape sinusoidal-check error, got: {s}"
+    );
+}
+
+#[test]
+fn decoder_rejects_bake_with_wrong_output_count() {
+    // 5 sinusoidal inputs but output dim = 1 (not 3) — should reject.
+    let num_freqs = 1usize;
+    let arity = 2 * num_freqs;
+    let expanded_dim = 5 * arity;
+    let scaler_mean = vec![0.0_f32; expanded_dim];
+    let scaler_scale = vec![1.0_f32; expanded_dim];
+    let l0_w = vec![0.0_f32; expanded_dim];
+    let l0_b = vec![0.0_f32; 1];
+    let layers = [BakeLayer {
+        in_dim: expanded_dim,
+        out_dim: 1,
+        activation: Activation::Identity,
+        dtype: WeightDtype::F32,
+        weights: &l0_w,
+        biases: &l0_b,
+    }];
+    let mut params = Vec::new();
+    for i in 0..5 {
+        if i > 0 {
+            params.push(b'\n');
+        }
+        params.push(b'1');
+    }
+    let metadata = [
+        BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORMS,
+            kind: MetadataType::Utf8,
+            value: b"sinusoidal\nsinusoidal\nsinusoidal\nsinusoidal\nsinusoidal",
+        },
+        BakeMetadataEntry {
+            key: keys::FEATURE_TRANSFORM_PARAMS,
+            kind: MetadataType::Utf8,
+            value: &params,
+        },
+    ];
+    let bytes = bake(&BakeRequest {
+        schema_hash: 1,
+        flags: 0,
+        scaler_mean: &scaler_mean,
+        scaler_scale: &scaler_scale,
+        layers: &layers,
+        feature_bounds: &[],
+        metadata: &metadata,
+        output_specs: &[],
+        discrete_sets: &[],
+        sparse_overrides: &[],
+        feature_order: None,
+        output_order: None,
+        compressed: false,
+        hu_permutations: None,
+    })
+    .expect("bake");
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    let err = match GainMapMlpDecoder::new(&model, 64, 64, GainMapMlpConfig::default()) {
+        Ok(_) => panic!("expected validate_bake_shape to reject this bake"),
+        Err(e) => e,
+    };
+    let s = format!("{err}");
+    assert!(
+        s.contains("n_outputs = 3"),
+        "expected n_outputs check error, got: {s}"
+    );
+}
+
+#[test]
+fn apply_pixel_reconstructs_with_constant_gain() {
+    // log2_gain = 1.0 ⇒ 2^1 = 2.0 gain ⇒ H = (S + ε) · 2 − ε
+    let bytes = make_constant_gain_bake(2, [1.0, 1.0, 1.0]);
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    let mut decoder =
+        GainMapMlpDecoder::new(&model, 64, 64, GainMapMlpConfig::default()).expect("construct");
+    let eps = decoder.epsilon();
+    let sdr = [0.5_f32, 0.25, 0.75];
+    let hdr = decoder.apply_pixel(0.5, 0.5, sdr).expect("apply");
+    let expected = [
+        (sdr[0] + eps) * 2.0 - eps,
+        (sdr[1] + eps) * 2.0 - eps,
+        (sdr[2] + eps) * 2.0 - eps,
+    ];
+    for c in 0..3 {
+        assert!(
+            (hdr[c] - expected[c]).abs() < 1e-5,
+            "channel {c}: got {} expected {}",
+            hdr[c],
+            expected[c]
+        );
+    }
+}
+
+#[test]
+fn apply_pixel_per_channel_gains_differ() {
+    // R doubles, G unchanged (log2_gain=0), B halves (log2_gain=-1).
+    let bytes = make_constant_gain_bake(2, [1.0, 0.0, -1.0]);
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    let mut decoder =
+        GainMapMlpDecoder::new(&model, 64, 64, GainMapMlpConfig::default()).expect("construct");
+    let eps = decoder.epsilon();
+    let sdr = [0.5_f32, 0.5, 0.5];
+    let hdr = decoder.apply_pixel(0.0, 0.0, sdr).expect("apply");
+    let expected_r = (sdr[0] + eps) * 2.0 - eps;
+    let expected_g = (sdr[1] + eps) * 1.0 - eps; // 2^0 = 1
+    let expected_b = (sdr[2] + eps) * 0.5 - eps;
+    assert!((hdr[0] - expected_r).abs() < 1e-5);
+    assert!((hdr[1] - expected_g).abs() < 1e-5);
+    assert!((hdr[2] - expected_b).abs() < 1e-5);
+}
+
+#[test]
+fn apply_row_runs_full_width() {
+    // 8-pixel row through a constant-log2-gain=0 bake: H == S
+    // exactly (because 2^0 = 1 ⇒ H = (S + ε) − ε = S).
+    let bytes = make_constant_gain_bake(2, [0.0, 0.0, 0.0]);
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    let mut decoder =
+        GainMapMlpDecoder::new(&model, 8, 1, GainMapMlpConfig::default()).expect("construct");
+    let sdr_row: Vec<f32> = (0..8 * 3).map(|i| (i as f32) / 24.0).collect();
+    let mut hdr_row = vec![0.0_f32; 8 * 3];
+    decoder.apply_row(0, &sdr_row, &mut hdr_row).expect("row");
+    for i in 0..8 * 3 {
+        // ε cancels exactly only when 2^0 = 1 — verify bit-close.
+        assert!(
+            (hdr_row[i] - sdr_row[i]).abs() < 1e-5,
+            "i={i}: hdr={} sdr={}",
+            hdr_row[i],
+            sdr_row[i]
+        );
+    }
+}
+
+#[test]
+fn apply_image_recovers_constant_doubling() {
+    // 4 × 4 image, constant log2_gain = 1.0 ⇒ every channel doubles
+    // around the ε offset.
+    let bytes = make_constant_gain_bake(2, [1.0, 1.0, 1.0]);
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    let mut decoder =
+        GainMapMlpDecoder::new(&model, 4, 4, GainMapMlpConfig::default()).expect("construct");
+    let eps = decoder.epsilon();
+    let sdr: Vec<f32> = (0..4 * 4 * 3).map(|i| (i as f32) / 48.0).collect();
+    let mut hdr = vec![0.0_f32; 4 * 4 * 3];
+    decoder.apply_image(4, 4, &sdr, &mut hdr).expect("image");
+    for i in 0..sdr.len() {
+        let expected = (sdr[i] + eps) * 2.0 - eps;
+        assert!(
+            (hdr[i] - expected).abs() < 1e-5,
+            "i={i}: hdr={} expected={}",
+            hdr[i],
+            expected
+        );
+    }
+}
+
+#[test]
+fn apply_image_rejects_mismatched_buffer_size() {
+    let bytes = make_constant_gain_bake(2, [0.0, 0.0, 0.0]);
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    let mut decoder =
+        GainMapMlpDecoder::new(&model, 4, 4, GainMapMlpConfig::default()).expect("construct");
+    let sdr = vec![0.0_f32; 4 * 4 * 3];
+    // hdr too small
+    let mut hdr_short = vec![0.0_f32; 4 * 4 * 3 - 1];
+    assert!(decoder.apply_image(4, 4, &sdr, &mut hdr_short).is_err());
+    // dimensions don't match buffer length
+    let mut hdr_ok = vec![0.0_f32; 4 * 4 * 3];
+    assert!(decoder.apply_image(8, 4, &sdr, &mut hdr_ok).is_err());
+}
+
+#[test]
+fn decoder_rejects_zero_dimensions() {
+    let bytes = make_constant_gain_bake(1, [0.0, 0.0, 0.0]);
+    let aligned = Aligned(bytes);
+    let model = Model::from_bytes(&aligned.0).unwrap();
+    assert!(GainMapMlpDecoder::new(&model, 0, 32, GainMapMlpConfig::default()).is_err());
+    assert!(GainMapMlpDecoder::new(&model, 32, 0, GainMapMlpConfig::default()).is_err());
+}

--- a/tools/train_gain_mlp.py
+++ b/tools/train_gain_mlp.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Standalone Gain-MLP trainer for zentone::gainmap_mlp.
+
+Implements Canham, Pieper, Sankaranarayanan, Roghair, Mueller (2025),
+"Encoding High-Dynamic-Range Gain Maps with Small MLPs" — the
+per-image training procedure that produces a ~10 KB MLP encoding the
+HDR/SDR log2 gain residual.
+
+The output of this script is a `BakeRequestJson` (zenpredict-bake's
+canonical input format). The companion `zenpredict-bake` CLI converts
+the JSON to a ZNPR v3 binary that `zentone::GainMapMlpDecoder` loads
+at runtime.
+
+USAGE
+-----
+
+    python3 train_gain_mlp.py \\
+        --hdr path/to/hdr.{png,npy,exr} \\
+        --sdr path/to/sdr.{png,npy} \\
+        --out gainmlp.bin \\
+        [--bake-bin /path/to/zenpredict-bake] \\
+        [--epochs 1000] [--lr 1e-2] [--batch 65536] \\
+        [--hidden 16] [--num-freqs 12] [--epsilon 0.015625]
+
+PIPELINE
+--------
+
+1. Load HDR + SDR image pair.
+2. Compute per-pixel log2 gain target:  `log2((H + ε) / (S + ε))`.
+3. Optionally run meta-initialisation: 10 000 iters on synthetic Daly-style
+   chromatic-noise patterns. Initial weights for the per-image fit.
+4. Per-image fit: Adam 1000 iters, lr 1e-2, batch 65 536 random pixels.
+5. Compute scaler statistics (mean / scale) over the 120-D embedded
+   inputs across a deterministic 4 096-pixel sample.
+6. Emit BakeRequestJson with the trained weights, scaler stats, and
+   the required `feature_transforms = sinusoidal × 5` +
+   `feature_transform_params = "1,2,4,...,2^(num_freqs-1)"` metadata.
+7. Optionally invoke `zenpredict-bake <json> <bin>` to materialise the
+   ZNPR v3 binary.
+
+The script is **per-image** by design (Canham §3.2) — there is no
+batch trainer. For a fleet, invoke per-image in parallel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+
+# ---------------------------------------------------------------------------
+# Sinusoidal positional embedding — matches FeatureTransform::Sinusoidal
+# in zenpredict (see ../../zenanalyze/zenpredict/src/feature_transform.rs).
+# ---------------------------------------------------------------------------
+
+
+def sinusoidal_embed(x: torch.Tensor, frequencies: torch.Tensor) -> torch.Tensor:
+    """
+    Embed `x` (shape (..., D)) into (..., D * 2 * F) by computing
+    `[sin(2π·f·x), cos(2π·f·x)]` for each of the `F = frequencies.numel()`
+    frequencies on each of the `D` input dimensions.
+
+    Matches zenpredict's FeatureTransform::Sinusoidal contract exactly.
+    """
+    # x shape (..., D); frequencies shape (F,); out (..., D * 2 * F)
+    two_pi = 2.0 * math.pi
+    angles = two_pi * x.unsqueeze(-1) * frequencies  # (..., D, F)
+    sin = torch.sin(angles)
+    cos = torch.cos(angles)
+    interleaved = torch.stack([sin, cos], dim=-1)  # (..., D, F, 2)
+    return interleaved.reshape(*x.shape[:-1], x.shape[-1] * 2 * frequencies.numel())
+
+
+# ---------------------------------------------------------------------------
+# Gain-MLP architecture: linear → ReLU → linear, 3 outputs (per-channel
+# log2 gain). Matches the paper's two-layer × 16-neuron design.
+# ---------------------------------------------------------------------------
+
+
+class GainMLP(nn.Module):
+    def __init__(self, in_dim: int, hidden_dim: int = 16, out_dim: int = 3):
+        super().__init__()
+        self.fc1 = nn.Linear(in_dim, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, out_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = torch.relu(self.fc1(x))
+        return self.fc2(h)
+
+
+# ---------------------------------------------------------------------------
+# Daly-style chromatic noise — used for meta-init. The paper cites
+# Daly et al.'s spatiochromatic noise process; we approximate by
+# generating per-channel 1/f-spectrum noise in linear-light space.
+# ---------------------------------------------------------------------------
+
+
+def make_chromatic_noise(
+    h: int, w: int, alpha: float = 1.0, seed: int = 0
+) -> np.ndarray:
+    """Spatiochromatic 1/f noise per RGB channel in `[0, 1]` linear."""
+    rng = np.random.default_rng(seed)
+    out = np.empty((h, w, 3), dtype=np.float32)
+    fy = np.fft.fftfreq(h).reshape(-1, 1)
+    fx = np.fft.fftfreq(w).reshape(1, -1)
+    radius = np.sqrt(fy**2 + fx**2)
+    radius[0, 0] = 1.0  # avoid div0
+    spectrum = 1.0 / (radius**alpha)
+    spectrum[0, 0] = 0.0
+    for c in range(3):
+        noise = rng.standard_normal((h, w))
+        f_noise = np.fft.fft2(noise) * spectrum
+        spatial = np.real(np.fft.ifft2(f_noise))
+        spatial = (spatial - spatial.min()) / (np.ptp(spatial) + 1e-8)
+        out[:, :, c] = spatial.astype(np.float32)
+    return out
+
+
+def reinhard_tonemap(hdr: np.ndarray) -> np.ndarray:
+    """Simple global Reinhard tone-map: y = x / (1 + x). Used for the
+    meta-init SDR counterpart."""
+    return hdr / (1.0 + hdr)
+
+
+# ---------------------------------------------------------------------------
+# Training core.
+# ---------------------------------------------------------------------------
+
+
+def build_pixel_targets(
+    hdr_image: np.ndarray,
+    sdr_image: np.ndarray,
+    epsilon: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Returns (inputs, targets) where inputs is `(N, 5)` of
+    `[x, y, R, G, B]` in `[0, 1]` and targets is `(N, 3)` of
+    per-channel log2 gain."""
+    assert hdr_image.shape == sdr_image.shape, "HDR/SDR shape mismatch"
+    h, w, c = hdr_image.shape
+    assert c == 3, "Only RGB supported"
+    ys = np.arange(h, dtype=np.float32) / max(h - 1, 1)
+    xs = np.arange(w, dtype=np.float32) / max(w - 1, 1)
+    yy, xx = np.meshgrid(ys, xs, indexing="ij")
+    flat_inputs = np.stack(
+        [
+            xx.flatten(),
+            yy.flatten(),
+            sdr_image[:, :, 0].flatten(),
+            sdr_image[:, :, 1].flatten(),
+            sdr_image[:, :, 2].flatten(),
+        ],
+        axis=1,
+    ).astype(np.float32)
+    # log2((H + ε) / (S + ε)) per channel
+    flat_targets = np.log2(
+        (hdr_image.reshape(-1, 3) + epsilon) / (sdr_image.reshape(-1, 3) + epsilon)
+    ).astype(np.float32)
+    return flat_inputs, flat_targets
+
+
+def train_one_image(
+    model: GainMLP,
+    frequencies: torch.Tensor,
+    inputs: np.ndarray,
+    targets: np.ndarray,
+    epochs: int,
+    lr: float,
+    batch: int,
+    device: torch.device,
+) -> float:
+    inputs_t = torch.from_numpy(inputs).to(device)
+    targets_t = torch.from_numpy(targets).to(device)
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+    n = inputs_t.shape[0]
+    last_loss = float("inf")
+    for ep in range(epochs):
+        idx = torch.randint(0, n, (batch,), device=device)
+        x = inputs_t[idx]
+        y = targets_t[idx]
+        embed = sinusoidal_embed(x, frequencies)
+        out = model(embed)
+        loss = torch.mean((out - y) ** 2)
+        optim.zero_grad()
+        loss.backward()
+        optim.step()
+        last_loss = float(loss.item())
+    return last_loss
+
+
+def meta_initialise(
+    model: GainMLP,
+    frequencies: torch.Tensor,
+    iters: int,
+    lr: float,
+    batch: int,
+    device: torch.device,
+    seed: int,
+    img_count: int = 10,
+    size: int = 64,
+) -> float:
+    """Meta-init via gradient descent on `img_count` synthetic noise
+    images. Mirrors Canham §3.2's meta-initialisation step."""
+    rng_seed = seed
+    images: list[tuple[np.ndarray, np.ndarray]] = []
+    for k in range(img_count):
+        hdr = make_chromatic_noise(size, size, alpha=1.0, seed=rng_seed + k) * 4.0
+        sdr = reinhard_tonemap(hdr).clip(0.0, 1.0)
+        images.append(build_pixel_targets(hdr, sdr, epsilon=1.0 / 64.0))
+
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+    last_loss = float("inf")
+    for it in range(iters):
+        inputs_np, targets_np = images[it % len(images)]
+        inputs_t = torch.from_numpy(inputs_np).to(device)
+        targets_t = torch.from_numpy(targets_np).to(device)
+        n = inputs_t.shape[0]
+        idx = torch.randint(0, n, (min(batch, n),), device=device)
+        x = inputs_t[idx]
+        y = targets_t[idx]
+        embed = sinusoidal_embed(x, frequencies)
+        out = model(embed)
+        loss = torch.mean((out - y) ** 2)
+        optim.zero_grad()
+        loss.backward()
+        optim.step()
+        last_loss = float(loss.item())
+    return last_loss
+
+
+# ---------------------------------------------------------------------------
+# BakeRequestJson emission.
+# ---------------------------------------------------------------------------
+
+
+def compute_scaler_stats(
+    inputs: np.ndarray,
+    frequencies: np.ndarray,
+    sample_size: int = 4096,
+    seed: int = 0,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return an identity scaler (mean=0, scale=1).
+
+    The MLP is trained directly on raw sinusoidal embedding values
+    (which are inherently bounded to `[-1, 1]`) — no train-time
+    standardisation. The bake's scaler must therefore be the identity
+    transform, otherwise the runtime would apply `(embed - mean) / std`
+    that the trainer never saw, producing reconstruction garbage
+    (catastrophic train/serve skew).
+
+    `sample_size` / `seed` are kept in the signature for compatibility
+    with the on-disk JSON output format and in case a future trainer
+    variant decides to learn with standardisation; both arguments are
+    currently unused.
+
+    Discovered 2026-05-18 during the first synthetic-pair round-trip:
+    the original (mean / std) scaler dropped reconstruction PSNR to
+    11.5 dB versus the paper's 48.5 dB. Switching to identity recovers
+    the target.
+    """
+    _ = (inputs, frequencies, sample_size, seed)
+    in_dim = 5 * 2 * frequencies.size
+    return (np.zeros(in_dim, dtype=np.float32), np.ones(in_dim, dtype=np.float32))
+
+
+def build_bake_request(
+    model: GainMLP,
+    frequencies: np.ndarray,
+    scaler_mean: np.ndarray,
+    scaler_scale: np.ndarray,
+    schema_hash: int = 0xFEED_FACE_DEAD_BEEF,
+) -> dict:
+    fc1_w = model.fc1.weight.detach().cpu().numpy().astype(np.float32)
+    fc1_b = model.fc1.bias.detach().cpu().numpy().astype(np.float32)
+    fc2_w = model.fc2.weight.detach().cpu().numpy().astype(np.float32)
+    fc2_b = model.fc2.bias.detach().cpu().numpy().astype(np.float32)
+
+    # Sanity: layer dims add up.
+    in_dim = scaler_mean.size
+    assert fc1_w.shape == (model.fc1.out_features, in_dim), (
+        f"fc1_w shape {fc1_w.shape} != ({model.fc1.out_features}, {in_dim})"
+    )
+    hidden = model.fc1.out_features
+    out_dim = model.fc2.out_features
+
+    # Weight layout: zenpredict's saxpy_matmul indexes
+    # `w[input_idx * out_dim + output_idx]` (see
+    # zenpredict/src/inference.rs::saxpy_matmul_f32). PyTorch stores
+    # `nn.Linear.weight` as `(out_features, in_features)`; flattening
+    # that directly produces `w[c * in_dim + i]` (column-major from
+    # zenpredict's POV) which silently miscomputes every forward pass.
+    # Transpose before flatten so the C-order traversal yields the
+    # row-major (in_dim, out_dim) zenpredict expects.
+    fc1_w_zen = fc1_w.T.copy()  # (in_dim, hidden) C-order
+    fc2_w_zen = fc2_w.T.copy()  # (hidden, out_dim) C-order
+
+    layers = [
+        {
+            "in_dim": in_dim,
+            "out_dim": hidden,
+            "activation": "relu",
+            "dtype": "f32",
+            "weights": fc1_w_zen.flatten().tolist(),
+            "biases": fc1_b.tolist(),
+        },
+        {
+            "in_dim": hidden,
+            "out_dim": out_dim,
+            "activation": "identity",
+            "dtype": "f32",
+            "weights": fc2_w_zen.flatten().tolist(),
+            "biases": fc2_b.tolist(),
+        },
+    ]
+
+    transforms_line = "\n".join(["sinusoidal"] * 5)
+    freq_line = ",".join(str(float(f)) for f in frequencies)
+    params_line = "\n".join([freq_line] * 5)
+
+    return {
+        "schema_hash": schema_hash,
+        "scaler_mean": scaler_mean.tolist(),
+        "scaler_scale": scaler_scale.tolist(),
+        "layers": layers,
+        "feature_bounds": [],
+        "metadata": [
+            {
+                "key": "zentrain.feature_transforms",
+                "type": "utf8",
+                "text": transforms_line,
+            },
+            {
+                "key": "zentrain.feature_transform_params",
+                "type": "utf8",
+                "text": params_line,
+            },
+            {
+                "key": "zentone.gainmlp.epsilon",
+                "type": "utf8",
+                "text": "0.015625",
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers — accept .npy (preferred for HDR f32) or simple PNG /
+# any-format-pillow-can-load for SDR.
+# ---------------------------------------------------------------------------
+
+
+def load_hdr_npy(path: Path) -> np.ndarray:
+    arr = np.load(path)
+    if arr.ndim == 2:
+        arr = np.stack([arr] * 3, axis=-1)
+    assert arr.ndim == 3 and arr.shape[2] == 3, f"HDR shape {arr.shape}"
+    return arr.astype(np.float32)
+
+
+def load_sdr_image(path: Path) -> np.ndarray:
+    if path.suffix.lower() == ".npy":
+        return load_hdr_npy(path)
+    try:
+        from PIL import Image
+    except ImportError:  # pragma: no cover
+        sys.exit(
+            f"SDR loading from {path} requires PIL (`pip install pillow`) or "
+            "a precomputed .npy"
+        )
+    img = Image.open(path).convert("RGB")
+    arr = np.array(img, dtype=np.float32) / 255.0
+    return arr
+
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Train a Gain-MLP for zentone::gainmap_mlp.")
+    p.add_argument("--hdr", type=Path, help="HDR image (.npy linear-light float)")
+    p.add_argument("--sdr", type=Path, help="SDR image (.png, .npy, ...)")
+    p.add_argument("--out", type=Path, required=True, help="Output bake path (.bin)")
+    p.add_argument("--epochs", type=int, default=1000)
+    p.add_argument("--lr", type=float, default=1e-2)
+    p.add_argument("--batch", type=int, default=65536)
+    p.add_argument("--hidden", type=int, default=16)
+    p.add_argument(
+        "--num-freqs",
+        type=int,
+        default=12,
+        help="Number of frequencies per input dim (paper uses 12 ⇒ 24-D per input).",
+    )
+    p.add_argument("--epsilon", type=float, default=1.0 / 64.0)
+    p.add_argument(
+        "--meta-init",
+        action="store_true",
+        help="Run synthetic chromatic-noise meta-init before per-image fit.",
+    )
+    p.add_argument("--meta-iters", type=int, default=10000)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--bake-bin",
+        type=Path,
+        default=Path("/home/lilith/work/zen/zenanalyze--featuretransform-sinusoidal/target/release/zenpredict-bake"),
+        help="Path to zenpredict-bake binary",
+    )
+    p.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Emit BakeRequestJson but skip the zenpredict-bake invocation.",
+    )
+    p.add_argument(
+        "--synthetic-pair",
+        action="store_true",
+        help="Skip --hdr/--sdr and train on a single synthetic chromatic-noise pair (useful for smoke testing).",
+    )
+    p.add_argument(
+        "--dump-pair",
+        type=Path,
+        default=None,
+        help="If set, write the HDR + SDR training pair as <prefix>_hdr.npy / <prefix>_sdr.npy. "
+        "Used by the Rust gainmlp_roundtrip example to bit-exactly reload the training pair.",
+    )
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[gain-mlp] device: {device}")
+
+    # NeRF-style 2^k frequency schedule, k = 0..num_freqs-1.
+    frequencies = torch.tensor(
+        [float(1 << k) for k in range(args.num_freqs)], dtype=torch.float32, device=device
+    )
+    in_dim = 5 * 2 * args.num_freqs  # 5 raw × 2 (sin+cos) × F
+    print(f"[gain-mlp] frequencies: {frequencies.tolist()}")
+    print(f"[gain-mlp] expanded input dim: {in_dim}")
+
+    model = GainMLP(in_dim=in_dim, hidden_dim=args.hidden, out_dim=3).to(device)
+
+    if args.meta_init:
+        print(f"[gain-mlp] meta-init: {args.meta_iters} iters on chromatic noise")
+        loss = meta_initialise(
+            model,
+            frequencies,
+            iters=args.meta_iters,
+            lr=args.lr,
+            batch=args.batch,
+            device=device,
+            seed=args.seed,
+        )
+        print(f"[gain-mlp] meta-init final loss: {loss:.6f}")
+
+    if args.synthetic_pair:
+        print("[gain-mlp] training on synthetic chromatic-noise pair")
+        hdr = make_chromatic_noise(128, 128, alpha=1.0, seed=args.seed) * 4.0
+        sdr = reinhard_tonemap(hdr).clip(0.0, 1.0)
+    else:
+        if args.hdr is None or args.sdr is None:
+            sys.exit("--hdr and --sdr required (or pass --synthetic-pair)")
+        print(f"[gain-mlp] loading HDR {args.hdr} + SDR {args.sdr}")
+        hdr = load_hdr_npy(args.hdr)
+        sdr = load_sdr_image(args.sdr)
+        # Light alignment check
+        assert hdr.shape == sdr.shape, f"shape mismatch {hdr.shape} vs {sdr.shape}"
+
+    if args.dump_pair is not None:
+        hdr_path = args.dump_pair.with_name(args.dump_pair.name + "_hdr.npy")
+        sdr_path = args.dump_pair.with_name(args.dump_pair.name + "_sdr.npy")
+        np.save(hdr_path, hdr.astype(np.float32))
+        np.save(sdr_path, sdr.astype(np.float32))
+        print(f"[gain-mlp] dumped pair: {hdr_path} + {sdr_path}")
+
+    inputs, targets = build_pixel_targets(hdr, sdr, epsilon=args.epsilon)
+    print(f"[gain-mlp] training: {args.epochs} epochs, lr={args.lr}, batch={args.batch}")
+    final_loss = train_one_image(
+        model,
+        frequencies,
+        inputs,
+        targets,
+        epochs=args.epochs,
+        lr=args.lr,
+        batch=args.batch,
+        device=device,
+    )
+    print(f"[gain-mlp] final loss (MSE on log2 gain): {final_loss:.6f}")
+
+    # Compute scaler stats over the embedded inputs.
+    freqs_np = frequencies.cpu().numpy()
+    scaler_mean, scaler_scale = compute_scaler_stats(
+        inputs, freqs_np, sample_size=min(4096, inputs.shape[0]), seed=args.seed
+    )
+
+    # Round-trip quick sanity: forward pass on a 128-pixel sample and
+    # compare to the targets directly (helps catch dtype / dim bugs
+    # before the bake is even written).
+    model.eval()
+    with torch.no_grad():
+        idx = np.linspace(0, inputs.shape[0] - 1, 128, dtype=np.int64)
+        sample_in = torch.from_numpy(inputs[idx]).to(device)
+        sample_out = model(sinusoidal_embed(sample_in, frequencies))
+        recon_err = torch.mean((sample_out - torch.from_numpy(targets[idx]).to(device)) ** 2)
+        print(f"[gain-mlp] sample-128 reconstruction MSE: {recon_err.item():.6f}")
+
+    bake_request = build_bake_request(model.cpu(), freqs_np, scaler_mean, scaler_scale)
+
+    if args.json_only:
+        json_path = args.out.with_suffix(".json")
+        json_path.write_text(json.dumps(bake_request))
+        print(f"[gain-mlp] wrote JSON to {json_path} (--json-only)")
+        return 0
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, dir=args.out.parent or "."
+    ) as tmp:
+        json.dump(bake_request, tmp)
+        tmp_path = tmp.name
+    try:
+        bake_bin = args.bake_bin
+        if not bake_bin.exists():
+            sys.exit(
+                f"zenpredict-bake not found at {bake_bin} — pass --bake-bin or "
+                "build via `cargo build --release -p zenpredict-bake`"
+            )
+        cmd = [str(bake_bin), tmp_path, str(args.out)]
+        print(f"[gain-mlp] invoking: {' '.join(cmd)}")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stdout)
+            print(result.stderr, file=sys.stderr)
+            sys.exit(f"zenpredict-bake failed (exit {result.returncode})")
+        print(f"[gain-mlp] wrote bake to {args.out} ({args.out.stat().st_size} bytes)")
+    finally:
+        os.unlink(tmp_path)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements both sides of Canham et al. 2025 "Encoding High-Dynamic-Range Gain Maps with Small MLPs" for zentone:

- **Decoder runtime** (\`gainmap_mlp\` module, gated behind \`gainmap-mlp\` feature) — per-pixel \`H = (S + ε) · 2^MLP(x, y, R, G, B) − ε\` reconstruction backed by a ZNPR v3 bake.
- **Standalone Python trainer** (\`tools/train_gain_mlp.py\`) — per-image PyTorch fit + Daly-style chromatic-noise meta-init, emits BakeRequestJson + invokes \`zenpredict-bake\`.
- **End-to-end roundtrip example** (\`examples/gainmlp_roundtrip.rs\`) — loads a trained bake + HDR/SDR .npy pair, reconstructs, reports PSNR.

Stacked on top of zenanalyze#77 (FeatureTransform::Sinusoidal). Path-deps to \`../zenanalyze--featuretransform-sinusoidal/zenpredict\` while #77 is in review — flip to a published crate version once #77 lands and ships.

## Measured result

On a 128 × 128 synthetic chromatic-noise pair, 5000 epochs / batch 16384 / lr 1e-2:

| | This PR | Paper |
|---|---|---|
| PSNR | **52.7 dB** | 48.5 dB |
| Bake size | 9609 bytes | ~10 KB |

Exceeds the paper's reported target. The smoke test runs end-to-end via:

\`\`\`bash
python3 tools/train_gain_mlp.py --synthetic-pair --out /tmp/g.bin --dump-pair /tmp/g --epochs 5000
cargo run --release --example gainmlp_roundtrip --features gainmap-mlp -- /tmp/g.bin --hdr /tmp/g_hdr.npy --sdr /tmp/g_sdr.npy
\`\`\`

## Three bugs found + fixed during the first real round-trip

The unit tests on synthetic constant-gain bakes (8 tests, all passing) did not exercise the trainer↔decoder agreement. The first real round-trip exposed three train/serve skew bugs in sequence:

1. **Scaler mismatch (11.51 dB).** Trainer used raw embedded inputs; bake declared non-trivial mean/std. Fix: identity scaler (mean=0, scale=1).
2. **Weight layout transpose (11.14 → 26.89 dB).** PyTorch's \`nn.Linear.weight\` is \`(out, in)\`; zenpredict's matmul wants row-major \`(in, out)\`. Fix: transpose before flatten.
3. **Coord normalisation (26.89 → 47.18 dB).** Python used \`idx / (n-1)\`; Rust used \`idx / n\`. At the highest frequency (2048 cycles/unit), a single-pixel offset produces > π phase shift. Fix: \`Decoder::new\` precomputes \`1 / (n - 1)\`.

More training (1000 → 5000 epochs, batch 4096 → 16384): 47.18 → **52.69 dB**.

Each fix is documented inline in the commit (\`7039f06\`) with the specific dB delta it produced.

## API

- \`GainMapMlpDecoder<'a>\` — per-thread driver wrapping \`zenpredict::Predictor<'a>\`. Validates the 5-sinusoidal / 3-output bake shape at construction.
- \`.apply_image(width, height, &sdr, &mut hdr)\` — wholesale
- \`.apply_row(y_pixel, &sdr_row, &mut hdr_row)\` — row-by-row
- \`.apply_pixel(x_norm, y_norm, sdr)\` — single-pixel
- \`GainMapMlpConfig { epsilon: f32 }\` — ISO 21496-1 ε (default 1/64)

## Test plan

- [x] 8 integration tests at \`tests/gainmap_mlp_integration.rs\` — constant-gain bakes hand-built via \`zenpredict-bake\`, exercise reconstruction math + bake-shape rejection paths
- [x] Roundtrip example reports 52.7 dB on synthetic chromatic-noise pair (5000 epochs, batch 16384)
- [x] \`cargo clippy --features gainmap-mlp --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Default (no feature) and \`--no-default-features\` (no_std) builds unaffected — \`zenpredict\` dep is fully optional

## Honest scope notes

- The Python trainer's \`--meta-init\` flag implements the Daly-style chromatic-noise initialisation step from Canham §3.2 but is not yet validated against a real HDR corpus — synthetic-pair PSNR already meets the bar.
- Real-world validation (UltraHDR / HEIF Amd 1 tmap corpus) is the natural follow-up; the trainer accepts real \`--hdr foo.npy --sdr foo.png\` inputs today.
- Per-pixel forward is scalar (no batched SIMD). For 24 MP images on CPU this is ~5-10 s; matches the paper's reported \`~4 s on Quadro RTX 6000\`. SIMD-batched per-row forward is queued for follow-up.