### PR TITLE
docs(readme): document map_row's channels: u8 contract and name the gamut matrix consts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ let mut row = vec![0.3_f32, 0.5, 0.2, 0.7, 0.1, 0.9];
 tm.map_row(&mut row, 3); // 3 = RGB, 4 = RGBA (alpha preserved)
 ```
 
+`map_row` rewrites interleaved **linear-light** f32 in place to linear SDR. `channels` is a `u8` that must be 3 or 4 (any other value panics), and the row length must be a multiple of it. Output is mostly `[0, 1]`, though some unclamped curves slightly exceed it — the sRGB OETF and 8-bit quantization live in [`linear-srgb`](https://lib.rs/crates/linear-srgb), or use the fused `pipeline` kernels below for direct sRGB-`u8` output.
+
 Fused SIMD strip pipeline — PQ EOTF → tone map → BT.2020→BT.709 → soft clip → sRGB OETF:
 
 ```rust
@@ -90,6 +92,8 @@ Curves that need RGB→Y weights take them at construction. Use `LUMA_BT709`, `L
 | `sdr_hdr` | Reference-white scaling (100 ↔ 203 nits), OOTF gamma adjustments per BT.2408 §5.1 |
 | `pipeline` | Fused PQ/HLG → tone-map → BT.709 → soft-clip strip kernels, with optional sRGB-u8 output |
 | `gainmap` | `LumaGainMapSplitter`, `LumaToneMap`, `SplitConfig`, `SplitStats`, plus adapters and PQ/HLG row helpers |
+
+The six `gamut` matrices are public consts in the `gamut` module — `gamut::BT2020_TO_BT709`, `BT709_TO_BT2020`, `P3_TO_BT709`, `BT709_TO_P3`, `BT2020_TO_P3`, `P3_TO_BT2020` — applied with `gamut::apply_matrix` (one `[f32; 3]`), `gamut::apply_matrix_row` (interleaved, `channels: usize`), or `gamut::apply_matrix_row_simd` / `apply_matrix_row_simd_rgba` (a `&mut [[f32; 3]]` / `&mut [[f32; 4]]` strip). The common HDR step is `BT2020_TO_BT709`.
 
 ## Architecture
 


### PR DESCRIPTION
## What

Two small README fixes so a first-time user gets `map_row` and the gamut matrices right without reading source.

## Why

An **insulated "external developer" test** — an agent given *only* `README.md` (zentone has no public-API snapshot), no source, no hints — was asked to write a server HDR→SDR→sRGB8 path. It hit two avoidable snags:

1. **`map_row` channel type.** The example `tm.map_row(&mut row, 3)` uses an untyped literal, so the agent guessed `channels: usize`. The real signature is `channels: u8` (`src/tone_map.rs:53`), and it must be `3` or `4` — any other value **panics**. A `usize` guess wouldn't compile.
2. **Gamut matrices not named.** The agent needed BT.2020→BT.709 (the standard HDR step) but the README only says *"six gamut matrices (BT.709 ↔ BT.2020 ↔ Display P3)"* without naming the public consts, so it left a `// TODO` and assumed BT.709 input. They are `gamut::BT2020_TO_BT709` + five siblings (`src/gamut.rs:23-58`).

## The fix

- A one-line contract note under the `map_row` example: linear-light f32 in place → linear SDR, `channels: u8` ∈ {3,4} (else panic), output mostly `[0,1]`, OETF/quantization in `linear-srgb`.
- A sentence after the Utility-modules table naming the six `gamut` consts and the `apply_matrix` / `apply_matrix_row` (`channels: usize`) / `apply_matrix_row_simd[_rgba]` entry points, flagging `BT2020_TO_BT709` as the common HDR step.

This mirrors how the README already names the `LUMA_BT709` / `LUMA_BT2020` / `LUMA_P3` consts.

## Verification

README-only; no API or behavior change. Verified against source:

| Symbol | Location |
|---|---|
| `ToneMap::map_row(&self, &mut [f32], channels: u8)` (panics if ∉ {3,4}) | `src/tone_map.rs:53` |
| `BT2020_TO_BT709` + 5 siblings (`pub const [[f32; 3]; 3]`) | `src/gamut.rs:23-58` |
| `apply_matrix` / `apply_matrix_row` (`usize`) / `apply_matrix_row_simd[_rgba]` | `src/gamut.rs:66/75/217/229` |
| `pub mod gamut` (not re-exported at crate root) | `src/lib.rs:207` |

The README is not `include_str!`-compiled, so these are not doctests — correctness rests on the source check above. Part of a cross-crate doc-quality pass driven by insulated ignorant-agent tests.
